### PR TITLE
Update set of changefiles.

### DIFF
--- a/mmixware.cygport
+++ b/mmixware.cygport
@@ -14,13 +14,15 @@ the marketplace."
 HOMEPAGE="http://mmix.cs.hm.edu/"
 SRC_URI="
 	http://mmix.cs.hm.edu/src/mmix-${VERSION}.tgz
-	https://raw.githubusercontent.com/ascherer/mmix/local/abstime.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-arith.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-config.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-io.ch
+	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-mem.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-pipe.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmix-sim.ch
 	https://raw.githubusercontent.com/ascherer/mmix/local/mmixal.ch
+	https://raw.githubusercontent.com/ascherer/mmix/local/mmmix.ch
+	https://raw.githubusercontent.com/ascherer/mmix/local/mmotype.ch
 	http://mmix.cs.hm.edu/tools/mmoimg/mmoimg.ch
 "
 SRC_DIR="."

--- a/mmixware.cygport
+++ b/mmixware.cygport
@@ -1,6 +1,6 @@
 NAME="mmixware"
-VERSION=20131017
-RELEASE=2
+VERSION=20160804
+RELEASE=1
 CATEGORY="System"
 SUMMARY="MMIX simulators, assembler, and tools"
 DESCRIPTION="MMIX is a computer intended to illustrate machine-level aspects


### PR DESCRIPTION
`abstime` isn't really necessary and can be replaced by `date +%s`.

In order to collect the helper modules in a shared library object, function `read_hex()` is moved from `mmixal.w` to `mmix-mem.w` with two new changefiles.

Together with all other modules also `mmotype` now makes use of standard C99 integer types.